### PR TITLE
Add Nix flakes to main too

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+	"nodes": {
+		"nixpkgs": {
+			"locked": {
+				"lastModified": 1718606988,
+				"narHash": "sha256-pmjP5ePc1jz+Okona3HxD7AYT0wbrCwm9bXAlj08nDM=",
+				"owner": "NixOS",
+				"repo": "nixpkgs",
+				"rev": "38d3352a65ac9d621b0cd3074d3bef27199ff78f",
+				"type": "github"
+			},
+			"original": {
+				"id": "nixpkgs",
+				"type": "indirect"
+			}
+		},
+		"root": {
+			"inputs": {
+				"nixpkgs": "nixpkgs",
+				"utils": "utils"
+			}
+		},
+		"systems": {
+			"locked": {
+				"lastModified": 1681028828,
+				"narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+				"owner": "nix-systems",
+				"repo": "default",
+				"rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+				"type": "github"
+			},
+			"original": {
+				"owner": "nix-systems",
+				"repo": "default",
+				"type": "github"
+			}
+		},
+		"utils": {
+			"inputs": {
+				"systems": "systems"
+			},
+			"locked": {
+				"lastModified": 1710146030,
+				"narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+				"owner": "numtide",
+				"repo": "flake-utils",
+				"rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+				"type": "github"
+			},
+			"original": {
+				"owner": "numtide",
+				"repo": "flake-utils",
+				"type": "github"
+			}
+		}
+	},
+	"root": "root",
+	"version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,18 @@
+{
+  inputs = {
+    utils.url = "github:numtide/flake-utils";
+  };
+  outputs = { self, nixpkgs, utils }: utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = nixpkgs.legacyPackages.${system};
+    in
+    {
+      devShell = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          nodejs_20
+          corepack_20
+        ];
+      };
+    }
+  );
+}


### PR DESCRIPTION
Added Nix flakes for instant development environment. Type `nix develop` in the terminal and get stable Node and PNPM in the environment instantly. Now on the `main` branch.